### PR TITLE
Add admin analytics dashboard

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,34 @@
+# MCP Server Admin Analytics
+
+This server exposes an admin-only route for viewing Google Analytics metrics.
+
+## Configuration
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Set the following environment variables before starting the server:
+
+   - `ADMIN_TOKEN` – secret token required in the `Authorization` header for
+     all `/admin` requests.
+   - `GA_CREDENTIALS` – JSON string of your Google service account credentials.
+   - `GA_PROPERTY_ID` – Analytics property ID to query.
+
+   Example of starting the server:
+   ```bash
+   ADMIN_TOKEN=mysecret \
+   GA_CREDENTIALS='{"client_email":"...","private_key":"..."}' \
+   GA_PROPERTY_ID=123456789 \
+   npm start
+   ```
+
+## Using the Dashboard
+
+Navigate to `/admin/analytics.html` in your browser. You will be prompted for
+the admin token. The page fetches data from the `/admin/analytics` endpoint and
+renders a simple chart and table of the returned metrics.
+
+Only requests with the correct token are allowed, so keep the token secret and
+share it only with authorized administrators.

--- a/server/admin/analytics.html
+++ b/server/admin/analytics.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Analytics Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #chart { max-width: 600px; }
+    table { border-collapse: collapse; margin-top: 20px; }
+    th, td { border: 1px solid #ccc; padding: 8px 12px; }
+  </style>
+</head>
+<body>
+  <h1>Analytics Dashboard</h1>
+  <canvas id="chart" width="600" height="300"></canvas>
+  <table id="metricsTable">
+    <thead>
+      <tr><th>Metric</th><th>Value</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script>
+    async function loadData() {
+      const token = localStorage.getItem('adminToken') || prompt('Admin token:');
+      localStorage.setItem('adminToken', token);
+      const res = await fetch('/admin/analytics', {
+        headers: { 'Authorization': 'Bearer ' + token }
+      });
+      if (!res.ok) {
+        document.body.innerHTML = 'Failed to load analytics';
+        return;
+      }
+      const data = await res.json();
+      const rows = data.rows || [];
+      const labels = [];
+      const values = [];
+      const tbody = document.querySelector('#metricsTable tbody');
+      rows.forEach(r => {
+        const name = r.dimensionValues ? r.dimensionValues[0].value : 'Metric';
+        const value = r.metricValues[0].value;
+        labels.push(name);
+        values.push(Number(value));
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${name}</td><td>${value}</td>`;
+        tbody.appendChild(tr);
+      });
+      new Chart(document.getElementById('chart').getContext('2d'), {
+        type: 'bar',
+        data: { labels: labels, datasets: [{ label: 'Value', data: values }] },
+      });
+    }
+    loadData();
+  </script>
+</body>
+</html>

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "axios": "^1.6.7",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "googleapis": "^128.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Google Analytics route and token auth
- serve `/admin/analytics.html` dashboard
- document environment variables for GA credentials
- install `googleapis` package

## Testing
- `npm install --silent` *(fails: ERR_MODULE_NOT_FOUND due to offline environment)*
- `node index.js` *(fails: cannot find 'express' since packages not installed)*